### PR TITLE
WIP | Replace retrieving Storefront Shopware-related attributes

### DIFF
--- a/src/Rule/v65/ShopwareRequestInitializedRector.php
+++ b/src/Rule/v65/ShopwareRequestInitializedRector.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Frosh\Rector\Rule\v65;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Expression;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class ShopwareRequestInitializedRector extends AbstractRector
+{
+    use ShopwareRequestTrait;
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Replace retrieving Shopware-related attributes from $request by ShopwareRequest', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+$salesChannelId = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, '');
+CODE_SAMPLE
+                ,
+                <<<'PHP'
+$shopware = $request->attributes->get(ShopwareRequest::ATTRIBUTE_REQUEST);
+$salesChannelId = $shopware->saleChannelId;
+PHP
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [ClassMethod::class];
+    }
+
+    /**
+     * @param ClassMethod $node
+     */
+    public function refactor(Node $node)
+    {
+        $swRequest = $this->betterNodeFinder->findFirst($node, function (Node $subNode): bool
+        {
+            try {
+                return $this->isObjectType($subNode, new ObjectType('Shopware\\Storefront\\Framework\\Routing\\ShopwareRequest'));
+            } catch (\Exception $e) {
+                return false;
+            }
+        });
+        if ($swRequest !== null) {
+            return null;
+        }
+
+        /** @var MethodCall[] $methodCall */
+        $methodCall = $this->betterNodeFinder->findInstanceOf($node, MethodCall::class);
+        if (!count($methodCall)) {
+            return null;
+        }
+
+        /** @var Variable|null $isFoundInStmt */
+        $isFoundInStmt = null;
+        foreach ($methodCall as $method) {
+            if ($isFoundInStmt = $this->havingSwRequestTransformed($method)) {
+                break;
+            }
+        }
+
+        if (!$isFoundInStmt instanceof Variable) {
+            return null;
+        }
+
+        return $this->injectShopwareRequest($node, $isFoundInStmt);
+    }
+
+    private function injectShopwareRequest(ClassMethod $node, Variable $isFoundInStmt): ClassMethod
+    {
+        $request = $this->betterNodeFinder->findFirst($node, function (Node $subNode): bool
+        {
+            return $subNode instanceof Variable && $this->isObjectType($subNode, new ObjectType('Symfony\\Component\\HttpFoundation\\Request'));
+        });
+
+        $currentStmt = $this->betterNodeFinder->resolveCurrentStatement($request);
+
+        $position = 0;
+        foreach ($node->stmts as $stmt) {
+            if ($this->nodeComparator->areNodesEqual($stmt, $currentStmt)) {
+                break;
+            }
+            $position++;
+        }
+        array_splice($node->stmts, $position, 0, [$this->createShopwareRequest($isFoundInStmt->name)]);
+
+        return $node;
+    }
+
+    private function createShopwareRequest(string $swName): Node\Stmt
+    {
+        return new Expression(
+            new Assign(
+                new Variable('shopware'),
+                new MethodCall(new PropertyFetch(new Variable($swName), 'attributes'), 'get', [
+                    new Arg(new ClassConstFetch(new FullyQualified('Shopware\\Storefront\\Framework\\Routing\\ShopwareRequest'), 'ATTRIBUTE_REQUEST')),
+                ])
+            )
+        );
+    }
+}

--- a/src/Rule/v65/ShopwareRequestTrait.php
+++ b/src/Rule/v65/ShopwareRequestTrait.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Frosh\Rector\Rule\v65;
+
+use PhpParser\Builder\Class_;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+trait ShopwareRequestTrait
+{
+    protected array $ATTRIBUTES_REQUEST = [
+        'PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID' => 'saleChannelId',
+        'RequestTransformer::SALES_CHANNEL_BASE_URL' => 'saleChannelBaseUrl',
+        'RequestTransformer::SALES_CHANNEL_ABSOLUTE_BASE_URL' => 'saleChannelAbsoluteBaseUrl',
+        'RequestTransformer::STOREFRONT_URL' => 'storefrontUrl',
+        'RequestTransformer::SALES_CHANNEL_RESOLVED_URI' => 'saleChannelResolvedUri',
+        'RequestTransformer::ORIGINAL_REQUEST_URI' => 'originalRequestUri',
+        'SalesChannelRequest::ATTRIBUTE_IS_SALES_CHANNEL_REQUEST' => 'isSaleChannelRequest',
+        'SalesChannelRequest::ATTRIBUTE_DOMAIN_LOCALE' => 'domainLocale',
+        'SalesChannelRequest::ATTRIBUTE_DOMAIN_SNIPPET_SET_ID' => 'domainSnippetSetId',
+        'SalesChannelRequest::ATTRIBUTE_DOMAIN_CURRENCY_ID' => 'domainCurrencyId',
+        'SalesChannelRequest::ATTRIBUTE_DOMAIN_ID' => 'domainId',
+        'SalesChannelRequest::ATTRIBUTE_THEME_ID' => 'themeId',
+        'SalesChannelRequest::ATTRIBUTE_THEME_NAME' => 'themeName',
+        'SalesChannelRequest::ATTRIBUTE_THEME_BASE_NAME' => 'themeBaseName',
+        'SalesChannelRequest::ATTRIBUTE_SALES_CHANNEL_MAINTENANCE' => 'saleChannelMaintenance',
+        'SalesChannelRequest::ATTRIBUTE_SALES_CHANNEL_MAINTENANCE_IP_WHITLELIST' => 'saleChannelMaintenanceIpWhitelist',
+        'SalesChannelRequest::ATTRIBUTE_CANONICAL_LINK' => 'canonicalLink',
+    ];
+
+    protected function havingSwRequestTransformed(MethodCall $method): ?Variable
+    {
+        if (!$this->isName($method->name, 'get')) {
+            return null;
+        }
+
+        /** @var PropertyFetch $requestAttributes */
+        $requestAttributes = $method->var;
+        if (!$this->isObjectType($requestAttributes, new ObjectType('Symfony\\Component\\HttpFoundation\\ParameterBag')) || !$this->isName($requestAttributes, 'attributes')) {
+            return null;
+        }
+
+        /** @var Variable $caller */
+        $caller = $method->var->var ?? null;
+        if (!$caller instanceof Variable || !$this->isObjectType($caller, new ObjectType('Symfony\\Component\\HttpFoundation\\Request'))) {
+            return null;
+        }
+
+        /** @var Node|ClassConstFetch $arg1 */
+        $arg1 = $method->args[0]->value;
+        if (!$arg1 instanceof ClassConstFetch || $this->getTransformedShopwareAttr($arg1) === '') {
+            return null;
+        }
+
+        return $caller;
+    }
+
+    protected function classConstToString(ClassConstFetch $arg): string
+    {
+        return sprintf('%s::%s', $arg->class, $arg->name);
+    }
+
+    protected function getTransformedShopwareAttr($attr): string
+    {
+        $const = $this->classConstToString($attr);
+        if (\array_key_exists($const, $this->ATTRIBUTES_REQUEST)) {
+            return $this->ATTRIBUTES_REQUEST[$const];
+        }
+
+        $const = str_replace('Shopware\\Core\\', '', $const);
+        if (\array_key_exists($const, $this->ATTRIBUTES_REQUEST)) {
+            return $this->ATTRIBUTES_REQUEST[$const];
+        }
+
+        return '';
+    }
+}

--- a/src/Rule/v65/ShopwareRequestTransformedRector.php
+++ b/src/Rule/v65/ShopwareRequestTransformedRector.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Frosh\Rector\Rule\v65;
+
+use PhpParser\Builder\Class_;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class ShopwareRequestTransformedRector extends AbstractRector
+{
+    use ShopwareRequestTrait;
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Replace retrieving Shopware-related attributes from $request by ShopwareRequest', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+$salesChannelId = $request->attributes->get(PlatformRequest::ATTRIBUTE_SALES_CHANNEL_ID, '');
+CODE_SAMPLE
+                ,
+                <<<'PHP'
+$shopware = $request->attributes->get(ShopwareRequest::ATTRIBUTE_REQUEST);
+$salesChannelId = $shopware->saleChannelId;
+PHP
+            ),
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class];
+    }
+
+    /**
+     * @param MethodCall $node
+     */
+    public function refactor(Node $node)
+    {
+        $isFoundInStmt = $this->havingSwRequestTransformed($node);
+        if (!$isFoundInStmt instanceof Variable) {
+            return null;
+        }
+
+        /** @var Node|ClassConstFetch $arg1 */
+        $arg1 = $node->args[0]->value;
+        $swAttr = $this->getTransformedShopwareAttr($arg1);
+
+        return new PropertyFetch(new Variable('shopware'), $swAttr);
+    }
+}


### PR DESCRIPTION
**Description**
At the moment we apply different values to the request attributes inside the RequestTransformer class. This attributes are essential that they should not be hidden inside the request. The idea, we should create a new own DTO class with managing the related-Shopware attributes from the request.

**Solution**
Rector rules will search all instances and usages of **Symfony\Component\HttpFoundation\Request**, where it fetches all variables which will be covered by ShopwareRequest, and replace it by ShopwareRequest

```diff
-$host = $request->attributes->get(RequestTransformer::SALES_CHANNEL_ABSOLUTE_BASE_URL) . $request->attributes->get(RequestTransformer::SALES_CHANNEL_BASE_URL);
+$shopware = $request->attributes->get(ShopwareRequest::ATTRIBUTE_REQUEST);
+$host = $shopware->saleChannelAbsoluteBaseUrl . $shopware->saleChannelBaseUrl;
```