### PR TITLE
docs: update installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,10 @@ See available [Shopware rules](/docs/rector_rules_overview.md)
 
 ## Install
 
-This package is already part of [rector/rector](http://github.com/rectorphp/rector) package, so it works out of the box.
-
-All you need to do is install the main package, and you're good to go:
+Make sure to install both `frosh/shopware-rector` as well as `rector/rector`.
 
 ```bash
-composer req frosh/shopware-rector --dev
+composer req rector/rector frosh/shopware-rector --dev
 ```
 
 ## Use Sets


### PR DESCRIPTION
During the installation of `frosh/shopware-rector` I noticed that I also need to install `rector/rector` apart from how I read the installation guide. 

I've updated the Installation Docs to match what I need to do to get `frosh/shopware-rector` to work.
Also, I'm not sure whether the statement that this package is part of `rector/rector´ is still true, on first sight it seems not so, therefore I removed it. If I got something wrong here, please let me know, so I can rephrase the installation guide again.

To further optimize the installation experience of users, it would be possible to require `rector/rector` as a non-development dependency, like [`sabbelasichon/typo3-rector`](https://github.com/sabbelasichon/typo3-rector/blob/06e6c37cd57fb6c69a66f21e76f24419918cf385/composer.json#LL31C10-L31C17) does. Then it would be required to only install `frosh/shopware-rector` and `rector/rector` would be installed as a dependency of this package.

Since I'm not sure whether this would be a wanted change or not, I've just updated the installation docs. When those changes are wanted, I'll happily create a separate pull request.