### PR TITLE
Remove useless rector renaming line

### DIFF
--- a/config/v6.5/flysystem-v3.php
+++ b/config/v6.5/flysystem-v3.php
@@ -15,7 +15,6 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(
         RenameClassRector::class,
         [
-            'League\\Flysystem\\FilesystemOperator' => 'League\\Flysystem\\FilesystemOperator',
             'League\\Flysystem\\FilesystemInterface' => 'League\\Flysystem\\FilesystemOperator',
             'League\\Flysystem\\AdapterInterface' => 'League\\Flysystem\\FilesystemAdapter',
             'League\\Flysystem\\Memory\\MemoryAdapter' => 'League\\Flysystem\\InMemory\\InMemoryFilesystemAdapter',


### PR DESCRIPTION
This pull request removes a rector renaming rule where the old name and the new name are the same run into an endless loop.