### PR TITLE
Add rule for replaced snippetfileinterface

### DIFF
--- a/config/v6.5/renaming.php
+++ b/config/v6.5/renaming.php
@@ -88,6 +88,7 @@ return static function (RectorConfig $rectorConfig): void {
         [
             new InterfaceReplacedWithAbstractClass('Shopware\Core\Checkout\Cart\CartPersisterInterface', 'Shopware\Core\Checkout\Cart\AbstractCartPersister'),
             new InterfaceReplacedWithAbstractClass('Shopware\Core\Content\Sitemap\Provider\UrlProviderInterface', 'Shopware\Core\Content\Sitemap\Provider\AbstractUrlProvider'),
+            new InterfaceReplacedWithAbstractClass('Shopware\Core\System\Snippet\Files\SnippetFileInterface', 'Shopware\Core\System\Snippet\Files\GenericSnippetFile'),
         ],
     );
 


### PR DESCRIPTION
Adds a rule for the following change in Shopware 6.5:

Interface Shopware\Core\System\Snippet\Files\SnippetFileInterface has been replaced by Abstract Class Shopware\Core\System\Snippet\Files\GenericSnippetFile.
