### PR TITLE
Shopware 6.6 JsonFieldSerializer::encodeJson

### DIFF
--- a/config/shopware-6.6.0.php
+++ b/config/shopware-6.6.0.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->import(__DIR__ . '/v6.6/*');
+    $rectorConfig->import(__DIR__ . '/v6.6/renaming.php');
 
     $rectorConfig->importNames();
     $rectorConfig->importShortClasses(false);

--- a/config/v6.6/renaming.php
+++ b/config/v6.6/renaming.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
+use Rector\Renaming\Rector\StaticCall\RenameStaticMethodRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
+use Rector\Renaming\ValueObject\RenameStaticMethod;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
@@ -14,6 +16,13 @@ return static function (RectorConfig $rectorConfig): void {
         [
             new MethodCallRename('Shopware\Elasticsearch\Framework\Indexing\IndexerOffset', 'setNextDefinition', 'selectNextDefinition'),
             new MethodCallRename('Shopware\Elasticsearch\Framework\Indexing\IndexerOffset', 'setNextLanguage', 'selectNextLanguage'),
+        ],
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameStaticMethodRector::class,
+        [
+            new RenameStaticMethod('Shopware\Core\Framework\DataAbstractionLayer\FieldSerializer\JsonFieldSerializer', 'encodeJson', 'Shopware\Core\Framework\Util\Json', 'encode'),
         ],
     );
 };


### PR DESCRIPTION
One may not use glob imports anymore and add a new replacement for Shopware 6.6, I just noticed when porting a plugin to Shopware 6.6.