### PR TITLE
Skip vendor folders to not try apply rector on vendor folders next to source code files

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -5,4 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->skip([
+        '*/vendor/*',
+    ]);
 };


### PR DESCRIPTION
When I run extension-verifier on a plugin, that has its plugin file next to the composer.json, rector just tries to apply everything on the vendor folder. We should skip that.