### PR TITLE
feat: Add Shopware 6.8 cart permission constants renamings

### DIFF
--- a/config/shopware-6.8.0.php
+++ b/config/shopware-6.8.0.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/v6.8/renaming.php');
+};

--- a/config/v6.8/renaming.php
+++ b/config/v6.8/renaming.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
+use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../config.php');
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassConstFetchRector::class,
+        [
+            new RenameClassAndConstFetch('Shopware\Core\Checkout\Cart\AbstractCartPersister', 'PERSIST_CART_ERROR_PERMISSION', 'Shopware\Core\Checkout\CheckoutPermissions', 'PERSIST_CART_ERROR'),
+
+            new RenameClassAndConstFetch('Shopware\Core\Checkout\Cart\Delivery\DeliveryProcessor', 'SKIP_DELIVERY_PRICE_RECALCULATION', 'Shopware\Core\Checkout\CheckoutPermissions', 'SKIP_PRODUCT_STOCK_VALIDATION'),
+            new RenameClassAndConstFetch('Shopware\Core\Checkout\Cart\Delivery\DeliveryProcessor', 'SKIP_DELIVERY_TAX_RECALCULATION', 'Shopware\Core\Checkout\CheckoutPermissions', 'SKIP_DELIVERY_TAX_RECALCULATION'),
+
+            new RenameClassAndConstFetch('Shopware\Core\Checkout\Promotion\Cart\PromotionCollector', 'SKIP_PROMOTION', 'Shopware\Core\Checkout\CheckoutPermissions', 'SKIP_PROMOTION'),
+            new RenameClassAndConstFetch('Shopware\Core\Checkout\Promotion\Cart\PromotionCollector', 'SKIP_AUTOMATIC_PROMOTIONS', 'Shopware\Core\Checkout\CheckoutPermissions', 'SKIP_AUTOMATIC_PROMOTIONS'),
+            new RenameClassAndConstFetch('Shopware\Core\Checkout\Promotion\Cart\PromotionCollector', 'PIN_MANUAL_PROMOTIONS', 'Shopware\Core\Checkout\CheckoutPermissions', 'PIN_MANUAL_PROMOTIONS'),
+            new RenameClassAndConstFetch('Shopware\Core\Checkout\Promotion\Cart\PromotionCollector', 'PIN_AUTOMATIC_PROMOTIONS', 'Shopware\Core\Checkout\CheckoutPermissions', 'PIN_AUTOMATIC_PROMOTIONS'),
+
+            new RenameClassAndConstFetch('Shopware\Core\Content\Product\Cart\ProductCartProcessor', 'ALLOW_PRODUCT_PRICE_OVERWRITES', 'Shopware\Core\Checkout\CheckoutPermissions', 'ALLOW_PRODUCT_PRICE_OVERWRITES'),
+            new RenameClassAndConstFetch('Shopware\Core\Content\Product\Cart\ProductCartProcessor', 'ALLOW_PRODUCT_LABEL_OVERWRITES', 'Shopware\Core\Checkout\CheckoutPermissions', 'ALLOW_PRODUCT_LABEL_OVERWRITES'),
+            new RenameClassAndConstFetch('Shopware\Core\Content\Product\Cart\ProductCartProcessor', 'SKIP_PRODUCT_RECALCULATION', 'Shopware\Core\Checkout\CheckoutPermissions', 'SKIP_PRODUCT_RECALCULATION'),
+            new RenameClassAndConstFetch('Shopware\Core\Content\Product\Cart\ProductCartProcessor', 'SKIP_PRODUCT_STOCK_VALIDATION', 'Shopware\Core\Checkout\CheckoutPermissions', 'SKIP_PRODUCT_STOCK_VALIDATION'),
+            new RenameClassAndConstFetch('Shopware\Core\Content\Product\Cart\ProductCartProcessor', 'KEEP_INACTIVE_PRODUCT', 'Shopware\Core\Checkout\CheckoutPermissions', 'KEEP_INACTIVE_PRODUCT'),
+        ],
+    );
+};

--- a/rector.php
+++ b/rector.php
@@ -18,6 +18,6 @@ return static function (RectorConfig $rectorConfig): void {
         ShopwareSetList::SHOPWARE_6_6_4,
         ShopwareSetList::SHOPWARE_6_6_10,
         ShopwareSetList::SHOPWARE_6_7_0,
-        ShopwareSetList::SHOPWARE_6_7_8,
+        ShopwareSetList::SHOPWARE_6_8_0,
     ]);
 };

--- a/rector.php
+++ b/rector.php
@@ -18,5 +18,6 @@ return static function (RectorConfig $rectorConfig): void {
         ShopwareSetList::SHOPWARE_6_6_4,
         ShopwareSetList::SHOPWARE_6_6_10,
         ShopwareSetList::SHOPWARE_6_7_0,
+        ShopwareSetList::SHOPWARE_6_7_8,
     ]);
 };

--- a/src/Set/ShopwareSetList.php
+++ b/src/Set/ShopwareSetList.php
@@ -15,4 +15,6 @@ final class ShopwareSetList
     public const SHOPWARE_6_6_10 = __DIR__ . '/../../config/shopware-6.6.10.php';
 
     public const SHOPWARE_6_7_0 = __DIR__ . '/../../config/shopware-6.7.0.php';
+
+    public const SHOPWARE_6_8_0 = __DIR__ . '/../../config/shopware-6.8.0.php';
 }


### PR DESCRIPTION
See https://github.com/shopware/shopware/commit/b34550b6f70443ed5b989fe4b37cc939b4cb185e

The `CartBehavior::isRecalculation` still needs to be implemented, this PR only covers the renaming of the constants.