### PR TITLE
refactor: Remove not needed variable doctypes of constants

### DIFF
--- a/src/Set/ShopwareSetList.php
+++ b/src/Set/ShopwareSetList.php
@@ -6,28 +6,13 @@ namespace Frosh\Rector\Set;
 
 final class ShopwareSetList
 {
-    /**
-     * @var string
-     */
     public const SHOPWARE_6_5_0 = __DIR__ . '/../../config/shopware-6.5.0.php';
 
-    /**
-     * @var string
-     */
     public const SHOPWARE_6_6_0 = __DIR__ . '/../../config/shopware-6.6.0.php';
 
-    /**
-     * @var string
-     */
     public const SHOPWARE_6_6_4 = __DIR__ . '/../../config/shopware-6.6.4.php';
 
-    /**
-     * @var string
-     */
     public const SHOPWARE_6_6_10 = __DIR__ . '/../../config/shopware-6.6.10.php';
 
-    /**
-     * @var string
-     */
     public const SHOPWARE_6_7_0 = __DIR__ . '/../../config/shopware-6.7.0.php';
 }


### PR DESCRIPTION
As they are constants, the type can be inferred