### PR TITLE
Replace removed rule PropertyFetchToMethodCallRector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
   "license": "mit",
   "require": {
     "php": "^8.1",
-    "rector/rector": "~2.0"
+    "rector/rector": "~2.0",
+    "webmozart/assert": "^1.11"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.57",

--- a/config/v6.5/renaming.php
+++ b/config/v6.5/renaming.php
@@ -6,6 +6,8 @@ use Frosh\Rector\Rule\Class_\InterfaceReplacedWithAbstractClass;
 use Frosh\Rector\Rule\Class_\InterfaceReplacedWithAbstractClassRector;
 use Frosh\Rector\Rule\ClassConstructor\RemoveArgumentFromClassConstruct;
 use Frosh\Rector\Rule\ClassConstructor\RemoveArgumentFromClassConstructRector;
+use Frosh\Rector\Rule\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
+use Frosh\Rector\Rule\Transform\ValueObject\PropertyFetchToMethodCall;
 use Frosh\Rector\Rule\v65\FakerPropertyToMethodCallRector;
 use Frosh\Rector\Rule\v65\MigrateCaptchaAnnotationToRouteRector;
 use Frosh\Rector\Rule\v65\MigrateLoginRequiredAnnotationToRouteRector;
@@ -17,8 +19,6 @@ use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\MethodCallRename;
-use Rector\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
-use Rector\Transform\ValueObject\PropertyFetchToMethodCall;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');

--- a/src/Rule/Transform/Rector/Assign/PropertyFetchToMethodCallRector.php
+++ b/src/Rule/Transform/Rector/Assign/PropertyFetchToMethodCallRector.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Rector\Rule\Transform\Rector\Assign;
+
+use Frosh\Rector\Rule\Transform\ValueObject\PropertyFetchToMethodCall;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\Exception\ShouldNotHappenException;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Webmozart\Assert\Assert;
+
+final class PropertyFetchToMethodCallRector extends AbstractRector implements ConfigurableRectorInterface
+{
+    /**
+     * @var PropertyFetchToMethodCall[]
+     */
+    private array $propertiesToMethodCalls = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Replace properties assign calls be defined methods', [
+            new ConfiguredCodeSample(
+                <<<'CODE_SAMPLE'
+                    $result = $object->property;
+                    $object->property = $value;
+
+                    $bare = $object->bareProperty;
+                    CODE_SAMPLE,
+                <<<'CODE_SAMPLE'
+                    $result = $object->getProperty();
+                    $object->setProperty($value);
+
+                    $bare = $object->getConfig('someArg');
+                    CODE_SAMPLE,
+                [
+                    new PropertyFetchToMethodCall('SomeObject', 'property', 'getProperty', 'setProperty'),
+                    new PropertyFetchToMethodCall('SomeObject', 'bareProperty', 'getConfig', null, ['someArg']),
+                ],
+            ),
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Assign::class, PropertyFetch::class];
+    }
+
+    /**
+     * @param PropertyFetch|Assign $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($node instanceof Assign && $node->var instanceof PropertyFetch) {
+            return $this->processSetter($node);
+        }
+
+        if ($node instanceof PropertyFetch) {
+            return $this->processGetter($node);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param mixed[] $configuration
+     */
+    public function configure(array $configuration): void
+    {
+        Assert::allIsAOf($configuration, PropertyFetchToMethodCall::class);
+        $this->propertiesToMethodCalls = $configuration;
+    }
+
+    private function processSetter(Assign $assign): ?Node
+    {
+        /** @var PropertyFetch $propertyFetchNode */
+        $propertyFetchNode = $assign->var;
+
+        $propertyToMethodCall = $this->matchPropertyFetchCandidate($propertyFetchNode);
+        if (!$propertyToMethodCall instanceof PropertyFetchToMethodCall) {
+            return null;
+        }
+
+        if ($propertyToMethodCall->getNewSetMethod() === null) {
+            throw new ShouldNotHappenException();
+        }
+
+        $args = $this->nodeFactory->createArgs([$assign->expr]);
+
+        /** @var Variable $variable */
+        $variable = $propertyFetchNode->var;
+
+        return $this->nodeFactory->createMethodCall($variable, $propertyToMethodCall->getNewSetMethod(), $args);
+    }
+
+    private function processGetter(PropertyFetch $propertyFetch): ?Node
+    {
+        $propertyFetchToMethodCall = $this->matchPropertyFetchCandidate($propertyFetch);
+        if (!$propertyFetchToMethodCall instanceof PropertyFetchToMethodCall) {
+            return null;
+        }
+
+        // simple method name
+        if ($propertyFetchToMethodCall->getNewGetMethod() !== '') {
+            $methodCall = $this->nodeFactory->createMethodCall(
+                $propertyFetch->var,
+                $propertyFetchToMethodCall->getNewGetMethod(),
+            );
+
+            if ($propertyFetchToMethodCall->getNewGetArguments() !== []) {
+                $methodCall->args = $this->nodeFactory->createArgs($propertyFetchToMethodCall->getNewGetArguments());
+            }
+
+            return $methodCall;
+        }
+
+        return $propertyFetch;
+    }
+
+    private function matchPropertyFetchCandidate(PropertyFetch $propertyFetch): ?PropertyFetchToMethodCall
+    {
+        foreach ($this->propertiesToMethodCalls as $propertyToMethodCall) {
+            if (!$this->isName($propertyFetch, $propertyToMethodCall->getOldProperty())) {
+                continue;
+            }
+
+            if (!$this->isObjectType($propertyFetch->var, $propertyToMethodCall->getOldObjectType())) {
+                continue;
+            }
+
+            return $propertyToMethodCall;
+        }
+
+        return null;
+    }
+}

--- a/src/Rule/Transform/ValueObject/PropertyFetchToMethodCall.php
+++ b/src/Rule/Transform/ValueObject/PropertyFetchToMethodCall.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Rector\Rule\Transform\ValueObject;
+
+use PHPStan\Type\ObjectType;
+use Rector\Validation\RectorAssert;
+
+final class PropertyFetchToMethodCall
+{
+    /**
+     * @param mixed[] $newGetArguments
+     */
+    public function __construct(
+        private string $oldType,
+        private string $oldProperty,
+        private string $newGetMethod,
+        private ?string $newSetMethod = null,
+        private array $newGetArguments = [],
+    ) {
+        RectorAssert::className($oldType);
+        RectorAssert::propertyName($oldProperty);
+
+        RectorAssert::methodName($newGetMethod);
+        if (is_string($newSetMethod)) {
+            RectorAssert::methodName($newSetMethod);
+        }
+    }
+
+    public function getOldObjectType(): ObjectType
+    {
+        return new ObjectType($this->oldType);
+    }
+
+    public function getOldProperty(): string
+    {
+        return $this->oldProperty;
+    }
+
+    public function getNewGetMethod(): string
+    {
+        return $this->newGetMethod;
+    }
+
+    public function getNewSetMethod(): ?string
+    {
+        return $this->newSetMethod;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getNewGetArguments(): array
+    {
+        return $this->newGetArguments;
+    }
+}

--- a/tests/Rector/v65/FetchPropertyToMethodCallRector/FetchPropertyToMethodCallRectorTest.php
+++ b/tests/Rector/v65/FetchPropertyToMethodCallRector/FetchPropertyToMethodCallRectorTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Rector\Tests\Rector\v65\FetchPropertyToMethodCallRector;
+
+use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class FetchPropertyToMethodCallRectorTest extends AbstractFroshRectorTestCase
+{
+}

--- a/tests/Rector/v65/FetchPropertyToMethodCallRector/Fixture/FlowState.php.inc
+++ b/tests/Rector/v65/FetchPropertyToMethodCallRector/Fixture/FlowState.php.inc
@@ -1,0 +1,18 @@
+<?php
+namespace Frosh\Rector\Tests\Rector\v65\FetchPropertyToMethodCallRector\Fixture;
+
+use Shopware\Core\Content\Flow\Dispatching\FlowState;
+
+$a = new FlowState();
+$a->sequenceId;
+?>
+
+-----
+<?php
+namespace Frosh\Rector\Tests\Rector\v65\FetchPropertyToMethodCallRector\Fixture;
+
+use Shopware\Core\Content\Flow\Dispatching\FlowState;
+
+$a = new FlowState();
+$a->getSequenceId();
+?>

--- a/tests/Rector/v65/FetchPropertyToMethodCallRector/config/configured_rule.php
+++ b/tests/Rector/v65/FetchPropertyToMethodCallRector/config/configured_rule.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Frosh\Rector\Rule\Transform\Rector\Assign\PropertyFetchToMethodCallRector;
+use Frosh\Rector\Rule\Transform\ValueObject\PropertyFetchToMethodCall;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config_test.php');
+    $rectorConfig->ruleWithConfiguration(
+        PropertyFetchToMethodCallRector::class,
+        [new PropertyFetchToMethodCall(
+            'Shopware\Core\Content\Flow\Dispatching\FlowState',
+            'sequenceId',
+            'getSequenceId',
+            null,
+        )],
+    );
+};


### PR DESCRIPTION
`PropertyFetchToMethodCallRector` got removed from rector, so I moved it here, tests for the use case in 6.5 inclusive.

webmozart/assert got added as requirement