### PR TITLE
Update webmozart/assert version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": "^8.1",
     "rector/rector": "~2.0",
-    "webmozart/assert": "^1.11"
+    "webmozart/assert": "^1 || ^2"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.57",


### PR DESCRIPTION
This pull request updates the dependency version constraint for `webmozart/assert` in the `composer.json` file to allow both major version 1 and major version 2. This change improves compatibility with projects using either version.

* Dependency update:
  * [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L9-R9): Changed the `webmozart/assert` requirement from `^1.11` to `^1 || ^2` to support both version 1 and version 2.