### PR TITLE
feat: Add Shopware 6.8 EntitySearchResult getEntities() delegation rule

### DIFF
--- a/config/v6.8/renaming.php
+++ b/config/v6.8/renaming.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Frosh\Rector\Rule\Class_\InterfaceReplacedWithAbstractClass;
 use Frosh\Rector\Rule\Class_\InterfaceReplacedWithAbstractClassRector;
+use Frosh\Rector\Rule\v68\EntitySearchResultGetEntitiesRector;
 use Frosh\Rector\Rule\v68\ProductStreamBuilderBuildFiltersToEnrichCriteriaRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
@@ -12,6 +13,7 @@ use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
 
+    $rectorConfig->rule(EntitySearchResultGetEntitiesRector::class);
     $rectorConfig->rule(ProductStreamBuilderBuildFiltersToEnrichCriteriaRector::class);
 
     $rectorConfig->ruleWithConfiguration(

--- a/src/Rule/v68/EntitySearchResultGetEntitiesRector.php
+++ b/src/Rule/v68/EntitySearchResultGetEntitiesRector.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Rector\Rule\v68;
+
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Foreach_;
+use PHPStan\Type\ObjectType;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Rewrites usages of the EntitySearchResult methods that are deprecated for Shopware 6.8 to the
+ * getEntities() delegation their deprecation messages prescribe.
+ */
+final class EntitySearchResultGetEntitiesRector extends AbstractRector
+{
+    private const ENTITY_SEARCH_RESULT = 'Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult';
+
+    /**
+     * Methods deprecated with a "Use getEntities()->x() instead" replacement. Deprecated methods
+     * without such a replacement (add(), clear(), setEntity(), ...) have no mechanical rewrite
+     * and stay out of scope.
+     */
+    private const DELEGATED_METHODS = [
+        'count',
+        'fill',
+        'filter',
+        'filterAndReduceByProperty',
+        'filterByProperty',
+        'filterInstance',
+        'first',
+        'firstWhere',
+        'flatMap',
+        'fmap',
+        'get',
+        'getAt',
+        'getCustomFieldsValue',
+        'getCustomFieldsValues',
+        'getElements',
+        'getIds',
+        'getKeys',
+        'getList',
+        'has',
+        'insert',
+        'isEmpty',
+        'last',
+        'map',
+        'merge',
+        'reduce',
+        'remove',
+        'set',
+        'setCustomFields',
+        'slice',
+        'sort',
+        'sortByIdArray',
+    ];
+
+    /**
+     * Functions that consume the deprecated Countable/IteratorAggregate implementations
+     * through their first argument.
+     */
+    private const DELEGATED_FUNCTIONS = [
+        'count',
+        'iterator_count',
+        'iterator_to_array',
+        'sizeof',
+    ];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Delegate EntitySearchResult calls deprecated for Shopware 6.8 through getEntities()',
+            [
+                new CodeSample(
+                    <<<'PHP'
+                        $product = $result->first();
+                        foreach ($result as $entity) {
+                        }
+                        PHP,
+                    <<<'PHP'
+                        $product = $result->getEntities()->first();
+                        foreach ($result->getEntities() as $entity) {
+                        }
+                        PHP,
+                ),
+            ],
+        );
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [MethodCall::class, NullsafeMethodCall::class, Foreach_::class, FuncCall::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        return match (true) {
+            $node instanceof MethodCall, $node instanceof NullsafeMethodCall => $this->refactorMethodCall($node),
+            $node instanceof Foreach_ => $this->refactorForeach($node),
+            $node instanceof FuncCall => $this->refactorFuncCall($node),
+            default => null,
+        };
+    }
+
+    private function refactorMethodCall(MethodCall|NullsafeMethodCall $call): ?MethodCall
+    {
+        if (!$call->name instanceof Identifier || !\in_array($call->name->toString(), self::DELEGATED_METHODS, true)) {
+            return null;
+        }
+
+        if (!$this->isSearchResult($call->var)) {
+            return null;
+        }
+
+        // keep the original nullsafe short-circuit: $result?->first() becomes $result?->getEntities()->first()
+        $getEntities = $call instanceof NullsafeMethodCall
+            ? new NullsafeMethodCall($call->var, 'getEntities')
+            : new MethodCall($call->var, 'getEntities');
+
+        return new MethodCall($getEntities, $call->name, $call->args);
+    }
+
+    private function refactorForeach(Foreach_ $foreach): ?Foreach_
+    {
+        // iterating the result wrapper goes through the deprecated getIterator()
+        if (!$this->isSearchResult($foreach->expr)) {
+            return null;
+        }
+
+        $foreach->expr = new MethodCall($foreach->expr, 'getEntities');
+
+        return $foreach;
+    }
+
+    private function refactorFuncCall(FuncCall $call): ?FuncCall
+    {
+        if (!$call->name instanceof Name || !\in_array($call->name->toLowerString(), self::DELEGATED_FUNCTIONS, true)) {
+            return null;
+        }
+
+        $firstArg = $call->args[0] ?? null;
+        if (!$firstArg instanceof Arg || !$this->isSearchResult($firstArg->value)) {
+            return null;
+        }
+
+        $firstArg->value = new MethodCall($firstArg->value, 'getEntities');
+
+        return $call;
+    }
+
+    private function isSearchResult(Node $node): bool
+    {
+        return $this->isObjectType($node, new ObjectType(self::ENTITY_SEARCH_RESULT));
+    }
+}

--- a/stubs/Shopware/Core/Content/Product/SalesChannel/Listing/ProductListingResult.php
+++ b/stubs/Shopware/Core/Content/Product/SalesChannel/Listing/ProductListingResult.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Content\Product\SalesChannel\Listing;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+class ProductListingResult extends EntitySearchResult {}

--- a/stubs/Shopware/Core/Framework/DataAbstractionLayer/Entity.php
+++ b/stubs/Shopware/Core/Framework/DataAbstractionLayer/Entity.php
@@ -1,0 +1,5 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer;
+
+class Entity {}

--- a/stubs/Shopware/Core/Framework/DataAbstractionLayer/EntityCollection.php
+++ b/stubs/Shopware/Core/Framework/DataAbstractionLayer/EntityCollection.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer;
+
+class EntityCollection
+{
+    public function first(): ?Entity
+    {
+        return null;
+    }
+}

--- a/stubs/Shopware/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
+++ b/stubs/Shopware/Core/Framework/DataAbstractionLayer/Search/EntitySearchResult.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\DataAbstractionLayer\Search;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+class EntitySearchResult
+{
+    public function getEntities(): EntityCollection
+    {
+        return new EntityCollection();
+    }
+}

--- a/tests/Rector/v68/EntitySearchResultGetEntitiesRector/EntitySearchResultGetEntitiesRectorTest.php
+++ b/tests/Rector/v68/EntitySearchResultGetEntitiesRector/EntitySearchResultGetEntitiesRectorTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frosh\Rector\Tests\Rector\v68\EntitySearchResultGetEntitiesRector;
+
+use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
+
+/**
+ * @internal
+ *
+ * @covers \Frosh\Rector\Rule\v68\EntitySearchResultGetEntitiesRector
+ */
+final class EntitySearchResultGetEntitiesRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/count_functions.php.inc
+++ b/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/count_functions.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+function countFunctions(EntitySearchResult $result): array
+{
+    $count = count($result);
+
+    return [$count, iterator_to_array($result)];
+}
+
+?>
+-----
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+function countFunctions(EntitySearchResult $result): array
+{
+    $count = count($result->getEntities());
+
+    return [$count, iterator_to_array($result->getEntities())];
+}
+
+?>

--- a/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/foreach_result.php.inc
+++ b/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/foreach_result.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+function foreachResult(EntitySearchResult $result): void
+{
+    foreach ($result as $entity) {
+        var_dump($entity);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+function foreachResult(EntitySearchResult $result): void
+{
+    foreach ($result->getEntities() as $entity) {
+        var_dump($entity);
+    }
+}
+
+?>

--- a/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/nullsafe_first.php.inc
+++ b/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/nullsafe_first.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+function nullsafeFirst(?EntitySearchResult $result): ?object
+{
+    return $result?->first();
+}
+
+?>
+-----
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+function nullsafeFirst(?EntitySearchResult $result): ?object
+{
+    return $result?->getEntities()->first();
+}
+
+?>

--- a/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/repository_idiom.php.inc
+++ b/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/repository_idiom.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+function repositoryIdiom(EntitySearchResult $result): array
+{
+    if ($result->has('some-id')) {
+        return $result->getIds();
+    }
+
+    return array_keys($result->getElements());
+}
+
+?>
+-----
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+function repositoryIdiom(EntitySearchResult $result): array
+{
+    if ($result->getEntities()->has('some-id')) {
+        return $result->getEntities()->getIds();
+    }
+
+    return array_keys($result->getEntities()->getElements());
+}
+
+?>

--- a/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/simple_first.php.inc
+++ b/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/simple_first.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+function simpleFirst(EntitySearchResult $result): ?object
+{
+    return $result->first();
+}
+
+?>
+-----
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+function simpleFirst(EntitySearchResult $result): ?object
+{
+    return $result->getEntities()->first();
+}
+
+?>

--- a/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/skip_entity_collection.php.inc
+++ b/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/skip_entity_collection.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\EntityCollection;
+
+function skipEntityCollection(EntityCollection $collection): array
+{
+    $collection->first();
+    $count = count($collection);
+
+    foreach ($collection as $entity) {
+        var_dump($entity);
+    }
+
+    return [$count, $collection->getIds()];
+}
+
+?>

--- a/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/skip_not_delegated_methods.php.inc
+++ b/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/skip_not_delegated_methods.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Framework\DataAbstractionLayer\Entity;
+use Shopware\Core\Framework\DataAbstractionLayer\Search\EntitySearchResult;
+
+function skipNotDelegatedMethods(EntitySearchResult $result, Entity $entity): int
+{
+    $result->add($entity);
+
+    return $result->getTotal();
+}
+
+?>

--- a/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/skip_unrelated_class.php.inc
+++ b/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/skip_unrelated_class.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+class UnrelatedResult
+{
+    public function first(): ?object
+    {
+        return null;
+    }
+}
+
+function skipUnrelatedClass(UnrelatedResult $result): ?object
+{
+    return $result->first();
+}
+
+?>

--- a/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/subclass_product_listing_result.php.inc
+++ b/tests/Rector/v68/EntitySearchResultGetEntitiesRector/Fixture/subclass_product_listing_result.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
+
+function subclassResult(ProductListingResult $result): ?object
+{
+    return $result->first();
+}
+
+?>
+-----
+<?php
+
+namespace Shopware\Tests\Rector\Fixture;
+
+use Shopware\Core\Content\Product\SalesChannel\Listing\ProductListingResult;
+
+function subclassResult(ProductListingResult $result): ?object
+{
+    return $result->getEntities()->first();
+}
+
+?>

--- a/tests/Rector/v68/EntitySearchResultGetEntitiesRector/config/configured_rule.php
+++ b/tests/Rector/v68/EntitySearchResultGetEntitiesRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Frosh\Rector\Rule\v68\EntitySearchResultGetEntitiesRector;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/../../../../../config/config_test.php');
+    $rectorConfig->rule(EntitySearchResultGetEntitiesRector::class);
+};


### PR DESCRIPTION
Shopware 6.8 deprecates the direct accessor/iteration methods on `EntitySearchResult` (`first()`, `count()`, `getIds()`, `foreach` over the result, `count($result)`, ...) in favour of delegating through `getEntities()`. Under the active v6.8 feature flag the deprecated methods throw.

This adds `EntitySearchResultGetEntitiesRector` to the 6.8 set:

- rewrites the delegated method calls (`$result->first()` → `$result->getEntities()->first()`), preserving nullsafe calls (`$result?->first()` → `$result?->getEntities()->first()`);
- rewrites `foreach ($result as ...)` to `foreach ($result->getEntities() as ...)` (iteration goes through the deprecated `getIterator()`);
- rewrites `count()`/`iterator_to_array()`/`iterator_count()`/`sizeof()` when the first argument is a result;
- skips deprecated methods without a mechanical `getEntities()` replacement (`add()`, `clear()`, `setEntity()`, ...), calls on `EntityCollection` itself, and unrelated classes; subclasses like `ProductListingResult` are matched.

9 fixtures cover the transformations and skip cases; stubs for `EntitySearchResult`, `EntityCollection`, `Entity` and `ProductListingResult` added.

Context: this rule was originally proposed inside the shopware/shopware monorepo (shopware/shopware#18656) and review pointed it here as the proper home for reusable Shopware Rector rules.
