### PR TITLE
feat: Replace deprecated ShopwareStyle with SymfonyStyle

### DIFF
--- a/config/v6.5/renaming.php
+++ b/config/v6.5/renaming.php
@@ -48,6 +48,7 @@ return static function (RectorConfig $rectorConfig): void {
             'Shopware\Core\System\User\Service\UserProvisioner' => 'Shopware\Core\Maintenance\User\Service\UserProvisioner',
             'Shopware\Core\Framework\DataAbstractionLayer\EntityRepositoryInterface' => 'Shopware\Core\Framework\DataAbstractionLayer\EntityRepository',
             'Shopware\Core\System\SalesChannel\Entity\SalesChannelRepositoryInterface' => 'Shopware\Core\System\SalesChannel\Entity\SalesChannelRepository',
+            'Shopware\Core\Framework\Adapter\Console\ShopwareStyle' => 'Symfony\Component\Console\Style\SymfonyStyle',
         ],
     );
 

--- a/config/v6.6/renaming.php
+++ b/config/v6.6/renaming.php
@@ -34,6 +34,7 @@ return static function (RectorConfig $rectorConfig): void {
         [
             'Shopware\Core\Framework\DataAbstractionLayer\Event\BeforeDeleteEvent' => 'Shopware\Core\Framework\DataAbstractionLayer\Event\EntityDeleteEvent',
             'Shopware\Core\Framework\Api\Exception\ExceptionFailedException' => 'Shopware\Core\Framework\Api\Exception\ExpectationFailedException',
+            'Shopware\Core\Framework\Adapter\Console\ShopwareStyle' => 'Symfony\Component\Console\Style\SymfonyStyle',
         ],
     );
 

--- a/config/v6.7/renaming.php
+++ b/config/v6.7/renaming.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/../config.php');
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Shopware\Core\Framework\Adapter\Console\ShopwareStyle' => 'Symfony\Component\Console\Style\SymfonyStyle',
+        ],
+    );
 
     $rectorConfig->ruleWithConfiguration(
         RenameClassConstFetchRector::class,

--- a/config/v6.8/renaming.php
+++ b/config/v6.8/renaming.php
@@ -8,6 +8,7 @@ use Frosh\Rector\Rule\v68\EntitySearchResultGetEntitiesRector;
 use Frosh\Rector\Rule\v68\ProductStreamBuilderBuildFiltersToEnrichCriteriaRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\ClassConstFetch\RenameClassConstFetchRector;
+use Rector\Renaming\Rector\Name\RenameClassRector;
 use Rector\Renaming\ValueObject\RenameClassAndConstFetch;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -23,6 +24,13 @@ return static function (RectorConfig $rectorConfig): void {
                 'Shopware\Core\Content\ProductStream\Service\ProductStreamBuilderInterface',
                 '\Shopware\Core\Content\ProductStream\Service\AbstractProductStreamBuilder',
             ),
+        ],
+    );
+
+    $rectorConfig->ruleWithConfiguration(
+        RenameClassRector::class,
+        [
+            'Shopware\Core\Framework\Adapter\Console\ShopwareStyle' => 'Symfony\Component\Console\Style\SymfonyStyle',
         ],
     );
 


### PR DESCRIPTION
## Summary
- Adds `RenameClassRector` mapping from `Shopware\Core\Framework\Adapter\Console\ShopwareStyle` to `Symfony\Component\Console\Style\SymfonyStyle`
- Configured in all version renaming sets (v6.5–v6.8) so plugins can migrate ahead of the 6.8 removal

## Test plan
- [ ] Confirm rule is loaded via `ShopwareSetList` for 6.5–6.8 sets
- [ ] Run rector on a fixture using `ShopwareStyle` and verify import/type rename to `SymfonyStyle`