### PR TITLE
fix: Restore Rector 2.6.2 compatibility and add PHPStan

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -59,3 +59,28 @@ jobs:
 
     - name: Run PHP CS Fixer
       run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v4
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Run PHPStan
+      run: ./vendor/bin/phpstan analyse --memory-limit=1G --no-progress

--- a/composer.json
+++ b/composer.json
@@ -5,16 +5,17 @@
   "license": "mit",
   "require": {
     "php": "^8.1",
-    "rector/rector": "~2.0",
+    "rector/rector": "^2.6.2",
     "webmozart/assert": "^1 || ^2"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.57",
+    "phpstan/phpstan": "^2.0",
     "phpunit/phpunit": "^9.5",
     "symplify/easy-coding-standard": "~11.2"
   },
   "conflict": {
-    "rector/rector": "<2.0"
+    "rector/rector": "<2.6.2"
   },
   "autoload": {
     "psr-4": {
@@ -49,6 +50,7 @@
   },
   "scripts": {
     "phpunit": "phpunit",
+    "phpstan": "phpstan analyse --memory-limit=1G",
     "csfix": "php-cs-fixer fix",
     "docs": [
       "vendor/bin/rule-doc-generator generate src --output-file docs/rector_rules_overview.md --ansi"

--- a/config/shopware-6.5.0.php
+++ b/config/shopware-6.5.0.php
@@ -14,10 +14,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/v6.5/typehints.php');
 
     $rectorConfig->sets([
-        SymfonySetList::SYMFONY_54,
-        SymfonySetList::SYMFONY_60,
-        SymfonySetList::SYMFONY_61,
-        SymfonySetList::SYMFONY_62,
+        SymfonySetList::COMPOSER_BASED,
         SetList::PHP_74,
         SetList::PHP_80,
         SetList::PHP_81,

--- a/config/shopware-6.6.0.php
+++ b/config/shopware-6.6.0.php
@@ -12,9 +12,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/v6.6/exceptions.php');
 
     $rectorConfig->sets([
-        SymfonySetList::SYMFONY_63,
-        SymfonySetList::SYMFONY_64,
-        SymfonySetList::SYMFONY_70,
+        SymfonySetList::COMPOSER_BASED,
         LevelSetList::UP_TO_PHP_82,
     ]);
 

--- a/config/shopware-6.6.10.php
+++ b/config/shopware-6.6.10.php
@@ -7,6 +7,6 @@ use Rector\Symfony\Set\SymfonySetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        SymfonySetList::SYMFONY_72,
+        SymfonySetList::COMPOSER_BASED,
     ]);
 };

--- a/config/shopware-6.6.4.php
+++ b/config/shopware-6.6.4.php
@@ -7,6 +7,6 @@ use Rector\Symfony\Set\SymfonySetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        SymfonySetList::SYMFONY_71,
+        SymfonySetList::COMPOSER_BASED,
     ]);
 };

--- a/config/shopware-6.7.0.php
+++ b/config/shopware-6.7.0.php
@@ -14,8 +14,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->import(__DIR__ . '/v6.7/renaming.php');
 
     $rectorConfig->sets([
-        SymfonySetList::SYMFONY_71,
-        SymfonySetList::SYMFONY_72,
+        SymfonySetList::COMPOSER_BASED,
     ]);
 
     $rectorConfig->ruleWithConfiguration(AddEntityNameToEntityExtension::class, [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,11 @@
+parameters:
+    level: 8
+    paths:
+        - src
+        - config
+    phpVersion: 80100
+    treatPhpDocTypesAsCertain: false
+    bootstrapFiles:
+        - vendor/rector/rector/bootstrap.php
+    scanDirectories:
+        - stubs

--- a/src/Rule/ClassConstructor/MakeClassConstructorArgumentRequiredRector.php
+++ b/src/Rule/ClassConstructor/MakeClassConstructorArgumentRequiredRector.php
@@ -6,15 +6,15 @@ namespace Frosh\Rector\Rule\ClassConstructor;
 
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\New_;
-use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Type\ArrayType;
-use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\PHPStanStaticTypeMapper\Enum\TypeKind;
 use Rector\Rector\AbstractRector;
@@ -62,9 +62,6 @@ class MakeClassConstructorArgumentRequiredRector extends AbstractRector implemen
         ];
     }
 
-    /**
-     * @param ClassMethod|New_ $node
-     */
     public function refactor(Node $node): ?Node
     {
         if ($node instanceof Class_) {
@@ -79,6 +76,10 @@ class MakeClassConstructorArgumentRequiredRector extends AbstractRector implemen
                 return $node;
             }
 
+            return null;
+        }
+
+        if (!$node instanceof New_) {
             return null;
         }
 
@@ -135,23 +136,9 @@ class MakeClassConstructorArgumentRequiredRector extends AbstractRector implemen
                 continue;
             }
 
-            if ($config->getDefault()) {
-                /** @var Name $arg */
-                $arg = $this->typeMapper->mapPHPStanTypeToPhpParserNode($config->getDefault(), TypeKind::PARAM);
-
-                if ($config->getDefault() instanceof NullType) {
-                    if ($arg instanceof Identifier) {
-                        $arg = new Name($arg->name);
-                    }
-
-                    if ($arg === null) {
-                        $arg = new Name('null');
-                    }
-
-                    $arg = new ConstFetch($arg);
-                }
-
-                $node->args[$config->getPosition()] = new Arg($arg);
+            $defaultExpr = $this->createDefaultExpr($config->getDefault());
+            if ($defaultExpr instanceof Expr) {
+                $node->args[$config->getPosition()] = new Arg($defaultExpr);
             }
 
             $hasModified = true;
@@ -162,5 +149,20 @@ class MakeClassConstructorArgumentRequiredRector extends AbstractRector implemen
         }
 
         return null;
+    }
+
+    private function createDefaultExpr(?Type $defaultType): ?Expr
+    {
+        if ($defaultType === null) {
+            return null;
+        }
+
+        if ($defaultType->isNull()->yes()) {
+            return new ConstFetch(new Name('null'));
+        }
+
+        $mapped = $this->typeMapper->mapPHPStanTypeToPhpParserNode($defaultType, TypeKind::PARAM);
+
+        return $mapped instanceof Expr ? $mapped : null;
     }
 }

--- a/src/Rule/ClassMethod/ChangeReturnTypeOfClassMethodRector.php
+++ b/src/Rule/ClassMethod/ChangeReturnTypeOfClassMethodRector.php
@@ -21,20 +21,28 @@ class ChangeReturnTypeOfClassMethodRector extends AbstractRector implements Conf
         ];
     }
 
-    public function refactor(Node $node)
+    public function refactor(Node $node): ?Node
     {
+        if (!$node instanceof Node\Stmt\Class_) {
+            return null;
+        }
+
+        $hasChanged = false;
+
         foreach ($this->configuration as $config) {
             if (!$this->isObjectType($node, new ObjectType($config->class))) {
                 return null;
             }
 
-            /** @var Node\Stmt\ClassMethod $stmt */
             foreach ($node->stmts as $stmt) {
-                if ($stmt instanceof Node\Stmt\ClassMethod && $stmt->name->name === $config->method) {
+                if ($stmt instanceof Node\Stmt\ClassMethod && $stmt->name->toString() === $config->method) {
                     $stmt->returnType = new Node\Name\FullyQualified($config->returnType);
+                    $hasChanged = true;
                 }
             }
         }
+
+        return $hasChanged ? $node : null;
     }
 
     /**

--- a/src/Rule/Transform/Rector/Assign/PropertyFetchToMethodCallRector.php
+++ b/src/Rule/Transform/Rector/Assign/PropertyFetchToMethodCallRector.php
@@ -72,12 +72,12 @@ final class PropertyFetchToMethodCallRector extends AbstractRector implements Co
     }
 
     /**
-     * @param mixed[] $configuration
+     * @param PropertyFetchToMethodCall[] $configuration
      */
     public function configure(array $configuration): void
     {
-        Assert::allIsAOf($configuration, PropertyFetchToMethodCall::class);
-        $this->propertiesToMethodCalls = $configuration;
+        Assert::allIsInstanceOf($configuration, PropertyFetchToMethodCall::class);
+        $this->propertiesToMethodCalls = array_values($configuration);
     }
 
     private function processSetter(Assign $assign): ?Node

--- a/src/Rule/v65/ContextMetadataExtensionToStateRector.php
+++ b/src/Rule/v65/ContextMetadataExtensionToStateRector.php
@@ -49,17 +49,20 @@ class ContextMetadataExtensionToStateRector extends AbstractRector
             return null;
         }
 
-        if ((string) $node->name !== 'addExtension') {
+        if (!$this->isName($node->name, 'addExtension')) {
             return null;
         }
 
-        /** @var Node|ClassConstFetch $arg1 */
-        $arg1 = $node->args[0]->value;
-
-        if (!$arg1  instanceof ClassConstFetch || !\in_array($arg1->name->toString(), self::ALLOWED_CONSTS, true)) {
+        $firstArg = $node->getArgs()[0] ?? null;
+        if (!$firstArg instanceof Node\Arg) {
             return null;
         }
 
-        return new MethodCall($node->var, 'addState', [$node->args[0]]);
+        $arg1 = $firstArg->value;
+        if (!$arg1 instanceof ClassConstFetch || !$arg1->name instanceof Node\Identifier || !\in_array($arg1->name->toString(), self::ALLOWED_CONSTS, true)) {
+            return null;
+        }
+
+        return new MethodCall($node->var, 'addState', [$firstArg]);
     }
 }

--- a/src/Rule/v65/MigrateCaptchaAnnotationToRouteRector.php
+++ b/src/Rule/v65/MigrateCaptchaAnnotationToRouteRector.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Rule\v65;
 
-use PhpParser\Builder\Class_;
 use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
-use Rector\BetterPhpDocParser\PhpDoc\SpacelessPhpDocTagNode;
+use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
@@ -61,15 +62,16 @@ class MigrateCaptchaAnnotationToRouteRector extends AbstractRector
     {
         return [
             ClassMethod::class,
-            Node\Stmt\Class_::class,
+            Class_::class,
         ];
     }
 
-    /**
-     * @param ClassMethod|Class_ $node
-     */
-    public function refactor(Node $node)
+    public function refactor(Node $node): ?Node
     {
+        if (!$node instanceof ClassMethod && !$node instanceof Class_) {
+            return null;
+        }
+
         $phpDocInfo = $this->phpDocFactory->createFromNodeOrEmpty($node);
 
         $captchaAnnotation = $phpDocInfo->getByName('Captcha');
@@ -78,23 +80,29 @@ class MigrateCaptchaAnnotationToRouteRector extends AbstractRector
             return null;
         }
 
-        /** @var SpacelessPhpDocTagNode|null $route */
         $route = $phpDocInfo->getByName('Route');
-
-        if ($route === null) {
+        if (!$route instanceof PhpDocTagNode) {
             return null;
         }
 
-        if (!$route->value->getValue('defaults')) {
-            $route->value->values[] = new ArrayItemNode(new CurlyListNode([]), 'defaults');
+        $routeValue = $route->value;
+        if (!$routeValue instanceof DoctrineAnnotationTagValueNode) {
+            return null;
         }
 
-        /** @var CurlyListNode $list */
-        $list = $route->value->getValue('defaults')->value;
+        if ($routeValue->getValue('defaults') === null) {
+            $routeValue->values[] = new ArrayItemNode(new CurlyListNode([]), 'defaults');
+        }
 
-        /** @var ArrayItemNode $item */
+        $defaults = $routeValue->getValue('defaults');
+        if (!$defaults instanceof ArrayItemNode || !$defaults->value instanceof CurlyListNode) {
+            return null;
+        }
+
+        $list = $defaults->value;
+
         foreach ($list->values as $item) {
-            if ($item->key === '_captcha') {
+            if ($item instanceof ArrayItemNode && $item->key === '_captcha') {
                 return null;
             }
         }

--- a/src/Rule/v65/MigrateLoginRequiredAnnotationToRouteRector.php
+++ b/src/Rule/v65/MigrateLoginRequiredAnnotationToRouteRector.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Rule\v65;
 
-use PhpParser\Builder\Class_;
 use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
-use Rector\BetterPhpDocParser\PhpDoc\SpacelessPhpDocTagNode;
+use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
 use Rector\BetterPhpDocParser\PhpDoc\StringNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
@@ -43,15 +44,16 @@ class MigrateLoginRequiredAnnotationToRouteRector extends AbstractRector
     {
         return [
             ClassMethod::class,
-            Node\Stmt\Class_::class,
+            Class_::class,
         ];
     }
 
-    /**
-     * @param ClassMethod|Class_ $node
-     */
-    public function refactor(Node $node)
+    public function refactor(Node $node): ?Node
     {
+        if (!$node instanceof ClassMethod && !$node instanceof Class_) {
+            return null;
+        }
+
         $phpDocInfo = $this->phpDocFactory->createFromNodeOrEmpty($node);
 
         $loginRequired = $phpDocInfo->getByName('LoginRequired');
@@ -60,23 +62,29 @@ class MigrateLoginRequiredAnnotationToRouteRector extends AbstractRector
             return null;
         }
 
-        /** @var SpacelessPhpDocTagNode|null $route */
         $route = $phpDocInfo->getByName('Route');
-
-        if ($route === null) {
+        if (!$route instanceof PhpDocTagNode) {
             return null;
         }
 
-        if (!$route->value->getValue('defaults')) {
-            $route->value->values[] = new ArrayItemNode(new CurlyListNode([]), 'defaults');
+        $routeValue = $route->value;
+        if (!$routeValue instanceof DoctrineAnnotationTagValueNode) {
+            return null;
         }
 
-        /** @var CurlyListNode $list */
-        $list = $route->value->getValue('defaults')->value;
+        if ($routeValue->getValue('defaults') === null) {
+            $routeValue->values[] = new ArrayItemNode(new CurlyListNode([]), 'defaults');
+        }
 
-        /** @var ArrayItemNode $item */
+        $defaults = $routeValue->getValue('defaults');
+        if (!$defaults instanceof ArrayItemNode || !$defaults->value instanceof CurlyListNode) {
+            return null;
+        }
+
+        $list = $defaults->value;
+
         foreach ($list->values as $item) {
-            if ($item->key === '_loginRequired') {
+            if ($item instanceof ArrayItemNode && $item->key === '_loginRequired') {
                 return null;
             }
         }

--- a/src/Rule/v65/MigrateRouteScopeToRouteDefaults.php
+++ b/src/Rule/v65/MigrateRouteScopeToRouteDefaults.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Rule\v65;
 
-use PhpParser\Builder\Class_;
 use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
 use Rector\BetterPhpDocParser\PhpDoc\ArrayItemNode;
 use Rector\BetterPhpDocParser\PhpDoc\DoctrineAnnotationTagValueNode;
@@ -52,46 +53,62 @@ class MigrateRouteScopeToRouteDefaults extends AbstractRector
     {
         return [
             ClassMethod::class,
-            Node\Stmt\Class_::class,
+            Class_::class,
         ];
     }
 
-    /**
-     * @param ClassMethod|Class_ $node
-     */
-    public function refactor(Node $node)
+    public function refactor(Node $node): ?Node
     {
-        $phpDocInfo = $this->phpDocFactory->createFromNodeOrEmpty($node);
-
-        $routeScope = $phpDocInfo->getByName('RouteScope');
-
-        if ($routeScope === null) {
+        if (!$node instanceof ClassMethod && !$node instanceof Class_) {
             return null;
         }
 
-        /** @var SpacelessPhpDocTagNode|null $route */
-        $route = $phpDocInfo->getByName('Route');
+        $phpDocInfo = $this->phpDocFactory->createFromNodeOrEmpty($node);
 
-        if ($route === null) {
+        $routeScope = $phpDocInfo->getByName('RouteScope');
+        if (!$routeScope instanceof PhpDocTagNode) {
+            return null;
+        }
+
+        $routeScopeValue = $routeScope->value;
+        if (!$routeScopeValue instanceof DoctrineAnnotationTagValueNode) {
+            return null;
+        }
+
+        $route = $phpDocInfo->getByName('Route');
+        if (!$route instanceof PhpDocTagNode) {
             $route = new SpacelessPhpDocTagNode('@Route', new DoctrineAnnotationTagValueNode(new IdentifierTypeNode('@Route')));
             $phpDocInfo->addPhpDocTagNode($route);
         }
 
-        if (!$route->value->getValue('defaults')) {
-            $route->value->values[] = new ArrayItemNode(new CurlyListNode([]), 'defaults');
+        $routeValue = $route->value;
+        if (!$routeValue instanceof DoctrineAnnotationTagValueNode) {
+            return null;
         }
 
-        /** @var CurlyListNode $list */
-        $list = $route->value->getValue('defaults')->value;
+        if ($routeValue->getValue('defaults') === null) {
+            $routeValue->values[] = new ArrayItemNode(new CurlyListNode([]), 'defaults');
+        }
 
-        /** @var ArrayItemNode $item */
+        $defaults = $routeValue->getValue('defaults');
+        if (!$defaults instanceof ArrayItemNode || !$defaults->value instanceof CurlyListNode) {
+            return null;
+        }
+
+        $list = $defaults->value;
+
         foreach ($list->values as $item) {
-            if ($item->key === '_routeScope') {
+            if ($item instanceof ArrayItemNode && $item->key === '_routeScope') {
                 return null;
             }
         }
 
-        $list->values[] = new ArrayItemNode($routeScope->value->values[0]->value, new StringNode('_routeScope'));
+        $scopeItem = $routeScopeValue->values[0] ?? null;
+        if (!$scopeItem instanceof ArrayItemNode) {
+            return null;
+        }
+
+        $list->values[] = new ArrayItemNode($scopeItem->value, new StringNode('_routeScope'));
         $list->markAsChanged();
 
         $this->phpDocTagRemover->removeByName($phpDocInfo, 'RouteScope');

--- a/src/Rule/v65/ThumbnailGenerateSingleToMultiGenerateRector.php
+++ b/src/Rule/v65/ThumbnailGenerateSingleToMultiGenerateRector.php
@@ -51,9 +51,14 @@ class ThumbnailGenerateSingleToMultiGenerateRector extends AbstractRector
             return null;
         }
 
+        $firstArg = $node->getArgs()[0] ?? null;
+        if (!$firstArg instanceof Node\Arg) {
+            return null;
+        }
+
         $node->name = new Node\Identifier('generate');
         $node->args[0] = new Node\Arg(new New_(new Name\FullyQualified(MediaCollection::class), [
-            new Node\Arg(new Array_([new Node\Expr\ArrayItem($node->args[0]->value)])),
+            new Node\Arg(new Array_([new Node\Expr\ArrayItem($firstArg->value)])),
         ]));
 
         return $node;

--- a/src/Rule/v67/AddEntityNameToEntityExtension.php
+++ b/src/Rule/v67/AddEntityNameToEntityExtension.php
@@ -47,11 +47,12 @@ class AddEntityNameToEntityExtension extends AbstractRector implements Configura
         ];
     }
 
-    /**
-     * @param Node\Stmt\Class_ $node
-     */
     public function refactor(Node $node): ?Node
     {
+        if (!$node instanceof Node\Stmt\Class_) {
+            return null;
+        }
+
         if (!$this->isObjectType($node, new ObjectType('Shopware\Core\Framework\DataAbstractionLayer\EntityExtension'))) {
             return null;
         }
@@ -59,13 +60,16 @@ class AddEntityNameToEntityExtension extends AbstractRector implements Configura
         $foundGetEntityName = false;
         $targetDefinitionClass = null;
 
-        /** @var Node\Stmt\ClassMethod $stmt */
         foreach ($node->stmts as $stmt) {
-            if ((string) $stmt->name === 'getEntityName') {
+            if (!$stmt instanceof Node\Stmt\ClassMethod) {
+                continue;
+            }
+
+            if ($stmt->name->toString() === 'getEntityName') {
                 $foundGetEntityName = true;
             }
 
-            if ((string) $stmt->name === 'getDefinitionClass') {
+            if ($stmt->name->toString() === 'getDefinitionClass' && $stmt->stmts !== null) {
                 foreach ($stmt->stmts as $methodStmts) {
                     if ($methodStmts instanceof Node\Stmt\Return_) {
                         if ($methodStmts->expr instanceof Node\Expr\ClassConstFetch) {
@@ -79,9 +83,9 @@ class AddEntityNameToEntityExtension extends AbstractRector implements Configura
 
         if (!$this->backwardsCompatible) {
             // remove getDefinitionClass method
-            $node->stmts = array_filter($node->stmts, static function ($stmt) {
-                return (string) $stmt->name !== 'getDefinitionClass';
-            });
+            $node->stmts = array_values(array_filter($node->stmts, static function (Node\Stmt $stmt): bool {
+                return !$stmt instanceof Node\Stmt\ClassMethod || $stmt->name->toString() !== 'getDefinitionClass';
+            }));
         }
 
         if (!$foundGetEntityName) {

--- a/src/Rule/v67/AddLoggerToScheduledTaskConstructorRector.php
+++ b/src/Rule/v67/AddLoggerToScheduledTaskConstructorRector.php
@@ -8,7 +8,7 @@ use PhpParser\Node;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
 use Rector\ValueObject\MethodName;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class AddLoggerToScheduledTaskConstructorRector extends AbstractRector
@@ -42,12 +42,16 @@ final class AddLoggerToScheduledTaskConstructorRector extends AbstractRector
 
     public function refactor(Node $node): ?Node
     {
+        if (!$node instanceof Node\Stmt\Class_) {
+            return null;
+        }
+
         if (!$this->isObjectType($node, new ObjectType('Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler'))) {
             return null;
         }
 
         $constructor = $node->getMethod(MethodName::CONSTRUCT);
-        if (!$constructor instanceof Node\Stmt\ClassMethod) {
+        if (!$constructor instanceof Node\Stmt\ClassMethod || $constructor->stmts === null) {
             return null;
         }
 


### PR DESCRIPTION
## Summary

- Replace removed `SymfonySetList::SYMFONY_*` constants with `SymfonySetList::COMPOSER_BASED` so Shopware sets load on Rector 2.6.2.
- Require `rector/rector` `^2.6.2`.
- Add PHPStan level 8 for `src` and `config`, plus a CI job, so this class of breakage is reported automatically.
- Fix existing type issues so the new PHPStan job is green.

Fixes #65.

## Test plan

- [x] `vendor/bin/phpstan analyse` is clean
- [x] `vendor/bin/phpunit` — 31 tests pass
- [x] `vendor/bin/rector process --config config/shopware-6.7.0.php --dry-run` loads under Rector 2.6.2
- [ ] CI PHPStan / PHPUnit / CS jobs pass