### PR TITLE
chore: Require PHP 8.2 and upgrade PHPUnit and php-cs-fixer

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -40,14 +40,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -65,14 +65,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor
 composer.lock
 
 .phpunit.result.cache
+.phpunit.cache
 .php-cs-fixer.cache
 
 # Devenv

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -2,7 +2,7 @@
 
 /*
  * This document has been generated with
- * https://mlocati.github.io/php-cs-fixer-configurator/#version:3.68.3|configurator
+ * https://mlocati.github.io/php-cs-fixer-configurator/#version:3.95.18|configurator
  * you can change this configuration by importing this file.
  */
 return (new PhpCsFixer\Config())
@@ -11,7 +11,7 @@ return (new PhpCsFixer\Config())
         '@PhpCsFixer' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        '@PHP81Migration' => true,
+        '@PHP82Migration' => true,
         '@PHP80Migration:risky' => true,
         '@PER-CS2.0' => true,
         '@PER-CS2.0:risky' => true,

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,14 @@
   "type": "rector-extension",
   "license": "mit",
   "require": {
-    "php": "^8.1",
+    "php": "^8.2",
     "rector/rector": "^2.6.2",
     "webmozart/assert": "^1 || ^2"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.57",
+    "friendsofphp/php-cs-fixer": "^3.95",
     "phpstan/phpstan": "^2.0",
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^11.5",
     "symplify/easy-coding-standard": "~11.2"
   },
   "conflict": {
@@ -38,7 +38,7 @@
     "update-with-dependencies": true,
     "sort-packages": true,
     "platform": {
-      "php": "8.1.99"
+      "php": "8.2.99"
     }
   },
   "extra": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ parameters:
     paths:
         - src
         - config
-    phpVersion: 80100
+    phpVersion: 80200
     treatPhpDocTypesAsCertain: false
     bootstrapFiles:
         - vendor/rector/rector/bootstrap.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,13 +4,13 @@
         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
         bootstrap="tests/bootstrap.php"
         colors="true"
-        verbose="true"
+        cacheDirectory=".phpunit.cache"
 >
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
     <php>
         <ini name="memory_limit" value="-1"/>
     </php>

--- a/tests/Rector/AbstractFroshRectorTestCase.php
+++ b/tests/Rector/AbstractFroshRectorTestCase.php
@@ -4,25 +4,20 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 abstract class AbstractFroshRectorTestCase extends AbstractRectorTestCase
 {
-    /**
-     * @dataProvider provideData()
-     */
-    public function test($fileInfo): void
+    #[DataProvider('provideData')]
+    public function test(string $fileInfo): void
     {
         $this->doTestFile($fileInfo);
     }
 
-    /**
-     * @return \Iterator<SmartFileInfo>
-     */
-    public function provideData(): \Iterator
+    public static function provideData(): \Iterator
     {
-        return $this->yieldFilesFromDirectory(dirname((new \ReflectionClass(static::class))->getFileName()) . '/Fixture');
+        return self::yieldFilesFromDirectory(dirname((new \ReflectionClass(static::class))->getFileName()) . '/Fixture');
     }
 
     public function provideConfigFilePath(): string

--- a/tests/Rector/Class/InterfaceReplacedWithAbstractClassRector/InterfaceReplacedWithAbstractClassRectorTest.php
+++ b/tests/Rector/Class/InterfaceReplacedWithAbstractClassRector/InterfaceReplacedWithAbstractClassRectorTest.php
@@ -4,17 +4,11 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\Class\InterfaceReplacedWithAbstractClassRector;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
-final class InterfaceReplacedWithAbstractClassRectorTest extends AbstractFroshRectorTestCase
-{
-    public function provideData(): \Iterator
-    {
-        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
-    }
-}
+#[CoversNothing]
+final class InterfaceReplacedWithAbstractClassRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/ClassConstructor/MakeClassConstructorArgumentRequiredRector/RemoveArgumentFromClassConstructorRectorTest.php
+++ b/tests/Rector/ClassConstructor/MakeClassConstructorArgumentRequiredRector/RemoveArgumentFromClassConstructorRectorTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\ClassConstructor\MakeClassConstructorArgumentRequiredRector;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 final class RemoveArgumentFromClassConstructorRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/ClassConstructor/RemoveArgumentFromClassConstructorRector/RemoveArgumentFromClassConstructorRectorTest.php
+++ b/tests/Rector/ClassConstructor/RemoveArgumentFromClassConstructorRector/RemoveArgumentFromClassConstructorRectorTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\ClassConstructor\RemoveArgumentFromClassConstructorRector;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 final class RemoveArgumentFromClassConstructorRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/ClassMethod/AddArgumentToClassWithoutDefaultValueRector/AddArgumentToClassWithoutDefaultValueRectorTest.php
+++ b/tests/Rector/ClassMethod/AddArgumentToClassWithoutDefaultValueRector/AddArgumentToClassWithoutDefaultValueRectorTest.php
@@ -2,11 +2,11 @@
 
 namespace Frosh\Rector\Tests\Rector\ClassMethod\AddArgumentToClassWithoutDefaultValueRector;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 class AddArgumentToClassWithoutDefaultValueRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/ClassMethod/ChangeReturnTypeOfClassMethodRector/ChangeReturnTypeOfClassMethodRectorTest.php
+++ b/tests/Rector/ClassMethod/ChangeReturnTypeOfClassMethodRector/ChangeReturnTypeOfClassMethodRectorTest.php
@@ -2,11 +2,11 @@
 
 namespace Frosh\Rector\Tests\Rector\ClassMethod\ChangeReturnTypeOfClassMethodRector;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 class ChangeReturnTypeOfClassMethodRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v65/AbstractMessageHandlerToMessageSubscriberRector/AbstractMessageHandlerToMessageSubscriberRectorTest.php
+++ b/tests/Rector/v65/AbstractMessageHandlerToMessageSubscriberRector/AbstractMessageHandlerToMessageSubscriberRectorTest.php
@@ -2,11 +2,11 @@
 
 namespace Frosh\Rector\Tests\Rector\v65\AbstractMessageHandlerToMessageSubscriberRector;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 final class AbstractMessageHandlerToMessageSubscriberRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v65/AddBanAllToReverseProxyRector/AddBanAllToReverseProxyRectorTest.php
+++ b/tests/Rector/v65/AddBanAllToReverseProxyRector/AddBanAllToReverseProxyRectorTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\v65\AddBanAllToReverseProxyRector;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 final class AddBanAllToReverseProxyRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v65/ContextMetadataExtensionToStateRector/ContextMetadataExtensionToStateRectorTest.php
+++ b/tests/Rector/v65/ContextMetadataExtensionToStateRector/ContextMetadataExtensionToStateRectorTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\v65\ContextMetadataExtensionToStateRector;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 final class ContextMetadataExtensionToStateRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v65/FakerPropertyToMethodCallRector/FakerPropertyToMethodCallRectorTest.php
+++ b/tests/Rector/v65/FakerPropertyToMethodCallRector/FakerPropertyToMethodCallRectorTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\v65\FakerPropertyToMethodCallRector;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 class FakerPropertyToMethodCallRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v65/FetchPropertyToMethodCallRector/FetchPropertyToMethodCallRectorTest.php
+++ b/tests/Rector/v65/FetchPropertyToMethodCallRector/FetchPropertyToMethodCallRectorTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\v65\FetchPropertyToMethodCallRector;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 class FetchPropertyToMethodCallRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v65/MigrateCaptchaAnnotationToRoute/MigrateCaptchaAnnotationToRouteTest.php
+++ b/tests/Rector/v65/MigrateCaptchaAnnotationToRoute/MigrateCaptchaAnnotationToRouteTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\v65\MigrateCaptchaAnnotationToRoute;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 final class MigrateCaptchaAnnotationToRouteTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v65/MigrateLoginRequiredAnnotationToRouteRector/MigrateLoginRequiredAnnotationToRouteRectorTest.php
+++ b/tests/Rector/v65/MigrateLoginRequiredAnnotationToRouteRector/MigrateLoginRequiredAnnotationToRouteRectorTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\v65\MigrateLoginRequiredAnnotationToRouteRector;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 final class MigrateLoginRequiredAnnotationToRouteRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v65/MigrateRouteScopeToRouteDefaults/MigrateRouteScopeToRouteDefaultsTest.php
+++ b/tests/Rector/v65/MigrateRouteScopeToRouteDefaults/MigrateRouteScopeToRouteDefaultsTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\v65\MigrateRouteScopeToRouteDefaults;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 final class MigrateRouteScopeToRouteDefaultsTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v65/ThumbnailGenerateSingleToMultiGenerate/ThumbnailGenerateSingleToMultiGenerateTest.php
+++ b/tests/Rector/v65/ThumbnailGenerateSingleToMultiGenerate/ThumbnailGenerateSingleToMultiGenerateTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\v65\ThumbnailGenerateSingleToMultiGenerate;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 final class ThumbnailGenerateSingleToMultiGenerateTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v67/AddEntityNameToEntityExtension/AddEntityNameToEntityExtensionTest.php
+++ b/tests/Rector/v67/AddEntityNameToEntityExtension/AddEntityNameToEntityExtensionTest.php
@@ -2,11 +2,11 @@
 
 namespace Frosh\Rector\Tests\Rector\v67\AddEntityNameToEntityExtension;
 
+use PHPUnit\Framework\Attributes\CoversNothing;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @coversNothing
  */
+#[CoversNothing]
 class AddEntityNameToEntityExtensionTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v67/AddLoggerToScheduledTaskConstructorRector/AddLoggerToScheduledTaskConstructorRectorTest.php
+++ b/tests/Rector/v67/AddLoggerToScheduledTaskConstructorRector/AddLoggerToScheduledTaskConstructorRectorTest.php
@@ -2,11 +2,12 @@
 
 namespace Frosh\Rector\Tests\Rector\v67\AddLoggerToScheduledTaskConstructorRector;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Frosh\Rector\Rule\v67\AddLoggerToScheduledTaskConstructorRector;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @covers \Frosh\Rector\Rule\v67\AddLoggerToScheduledTaskConstructorRector
  */
+#[CoversClass(AddLoggerToScheduledTaskConstructorRector::class)]
 class AddLoggerToScheduledTaskConstructorRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v68/CartBehaviorIsRecalculationRector/CartBehaviorIsRecalculationRectorTest.php
+++ b/tests/Rector/v68/CartBehaviorIsRecalculationRector/CartBehaviorIsRecalculationRectorTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\v68\CartBehaviorIsRecalculationRector;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Frosh\Rector\Rule\v68\CartBehaviorIsRecalculationRector;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @covers \Frosh\Rector\Rule\v68\CartBehaviorIsRecalculationRector
  */
+#[CoversClass(CartBehaviorIsRecalculationRector::class)]
 final class CartBehaviorIsRecalculationRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v68/EntitySearchResultGetEntitiesRector/EntitySearchResultGetEntitiesRectorTest.php
+++ b/tests/Rector/v68/EntitySearchResultGetEntitiesRector/EntitySearchResultGetEntitiesRectorTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\v68\EntitySearchResultGetEntitiesRector;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Frosh\Rector\Rule\v68\EntitySearchResultGetEntitiesRector;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @covers \Frosh\Rector\Rule\v68\EntitySearchResultGetEntitiesRector
  */
+#[CoversClass(EntitySearchResultGetEntitiesRector::class)]
 final class EntitySearchResultGetEntitiesRectorTest extends AbstractFroshRectorTestCase {}

--- a/tests/Rector/v68/ProductStreamBuilderBuildFiltersToEnrichCriteriaRector/ProductStreamBuilderBuildFiltersToEnrichCriteriaRectorTest.php
+++ b/tests/Rector/v68/ProductStreamBuilderBuildFiltersToEnrichCriteriaRector/ProductStreamBuilderBuildFiltersToEnrichCriteriaRectorTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Frosh\Rector\Tests\Rector\v68\ProductStreamBuilderBuildFiltersToEnrichCriteriaRector;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use Frosh\Rector\Rule\v68\ProductStreamBuilderBuildFiltersToEnrichCriteriaRector;
 use Frosh\Rector\Tests\Rector\AbstractFroshRectorTestCase;
 
 /**
  * @internal
- *
- * @covers \Frosh\Rector\Rule\v68\ProductStreamBuilderBuildFiltersToEnrichCriteriaRector
  */
+#[CoversClass(ProductStreamBuilderBuildFiltersToEnrichCriteriaRector::class)]
 final class ProductStreamBuilderBuildFiltersToEnrichCriteriaRectorTest extends AbstractFroshRectorTestCase {}


### PR DESCRIPTION
## Summary
- Raise the minimum PHP version from 8.1 to 8.2 (`composer.json` + Composer platform + PHPStan `phpVersion`).
- Upgrade PHPUnit from 9.5 to 11.5, including the PHPUnit 11 config schema, static data providers, and attribute-based test metadata.
- Bump php-cs-fixer to `^3.95` and switch the migration ruleset to `@PHP82Migration`.
- Upgrade GitHub Actions to Node.js 24 runtimes: `actions/checkout@v7` and `actions/cache@v6`.

## Test plan
- [x] `./vendor/bin/phpunit` — 32 tests, 56 assertions
- [x] `./vendor/bin/phpstan analyse --memory-limit=1G --no-progress`
- [x] `./vendor/bin/php-cs-fixer fix --dry-run --diff`
- [ ] Confirm CI no longer warns about Node.js 20 deprecation